### PR TITLE
Post lists design

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -51,29 +51,12 @@ require_once( get_template_directory() . '/inc/init.php' );
 * More informations on how to create a child theme with Customizr here : http://themesandco.com/customizr/#child-theme
 */
 
-/* SPECIAL TREATMENT FOR IMAGE IN DOC */
-add_filter( 'the_content' , 'tc_add_dummy_image' );
 
-function tc_add_dummy_image( $content ) {
-  if ( ! isset( $_GET['lazy_load'] ) || 'true' != $_GET['lazy_load'] )
-    return $content;
+/*__return_false to disable it*/
+add_filter( 'tc_post_list_design', '__return_true');
 
-  if( is_feed() || is_preview() || wp_is_mobile() ) return $content;
-  if (strpos( $content, 'data-src' ) !== false) return $content;
-    $content = preg_replace_callback('#<img([^>]+?)src=[\'"]?([^\'"\s>]+)[\'"]?([^>]*)>#', 'tc_replace_callback', $content);
+add_filter('tc_post_list_design_cols', function(){
+    return 4;
+});
 
-  return $content;
-}
-
-function tc_replace_callback($matches) {
-  if ( ! isset( $_GET['lazy_load'] ) || 'true' != $_GET['lazy_load'] )
-    return $content;
-
-  $dummy_image = 'data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==';
-
-  if (preg_match('/ data-lazy *= *"false" */', $matches[0])){
-      return '<img' . $matches[1] . 'src="' . $matches[2] . '"' . $matches[3] . '>';
-  } else {
-      return '<img' . $matches[1] . 'src="' . $dummy_image . '" data-src="' . $matches[2] . '"' . $matches[3] . '><noscript><img' . $matches[1] . 'src="' . $matches[2] . '"' . $matches[3] . '></noscript>';
-  }
-}
+add_filter('tc_post_list_expand_featured', '__return_true');

--- a/inc/parts/class-content-post_list_design.php
+++ b/inc/parts/class-content-post_list_design.php
@@ -2,7 +2,7 @@
 /**
 * Post lists content actions
 *
-* 
+*
 * @package      Customizr
 * @subpackage   classes
 * @since        3.2.11
@@ -17,6 +17,81 @@ if ( ! class_exists( 'TC_post_list_design' ) ) :
         function __construct () {
             self::$instance =& $this;
             add_action ( '__before_article_container', array( $this , 'tc_post_list_design'), 0);
+            add_action('__before_loop' , array( $this , 'tc_alter_main_query') );
+        }
+
+        function tc_alter_main_query() {
+          global $wp_query;
+          $_query_vars    = $wp_query->query_vars;
+          $page           =  ( ! isset($_query_vars['paged']) || ! $_query_vars['paged'] ) ? 0 : $_query_vars['paged'];
+
+          if ( $page >= 1 )
+            return;
+
+          $sticky_posts   = get_option('sticky_posts');
+          $_posts_per_col = $this -> tc_get_post_list_cols();
+
+          $num_posts      = $wp_query->get('posts_per_page');
+
+          //maybe add posts to columns on first page of the post list
+          if ( is_array($sticky_posts) && ! empty($sticky_posts) && $_posts_per_col >= $num_posts ) {
+            $_div_rest = ( $num_posts - 1 ) % $_posts_per_col;
+
+            if ( 0 != $_div_rest )
+              $_query_vars['posts_per_page'] = $wp_query->get('posts_per_page') + $_posts_per_col - $_div_rest;
+          }
+
+          //overrides the query
+          $wp_query = new WP_query($_query_vars);
+
+          // Put sticky posts at the top of the posts array
+          if ( $page <= 1 && is_array($sticky_posts) && !empty($sticky_posts) && !$_query_vars['ignore_sticky_posts'] ) {
+
+            $sticky_offset = 0;
+            // Loop over posts and relocate stickies to the front.
+            for ( $i = 0; $i < $num_posts; $i++ ) {
+              if ( in_array($wp_query->posts[$i]->ID, $sticky_posts) ) {
+                $sticky_post = $wp_query->posts[$i];
+                // Remove sticky from current position
+                array_splice($wp_query->posts, $i, 1);
+                // Move to front, after other stickies
+                array_splice($wp_query->posts, $sticky_offset, 0, array($sticky_post));
+                // Increment the sticky offset. The next sticky will be placed at this offset.
+                $sticky_offset++;
+                // Remove post from sticky posts array
+                $offset = array_search($sticky_post->ID, $sticky_posts);
+                unset( $sticky_posts[$offset] );
+              }
+            }
+
+            // If any posts have been excluded specifically, Ignore those that are sticky.
+            if ( !empty($sticky_posts) && !empty($q['post__not_in']) )
+              $sticky_posts = array_diff($sticky_posts, $q['post__not_in']);
+
+            // Fetch sticky posts that weren't in the query results
+            if ( !empty($sticky_posts) ) {
+              $stickies = get_posts( array(
+                'post__in' => $sticky_posts,
+                'post_type' => $wp_query-> get( 'post_type' ),
+                'post_status' => 'publish',
+                'nopaging' => true
+              ) );
+
+              foreach ( $stickies as $sticky_post ) {
+                array_splice( $wp_query->posts, $sticky_offset, 0, array( $sticky_post ) );
+                $sticky_offset++;
+              }
+            }
+          }
+
+
+          /*?>
+            <pre>
+              <?php print_r($wp_query); ?>
+            </pre>
+          <?php*/
+          ?>
+          <?php
         }
 
         function tc_post_list_design(){
@@ -30,21 +105,21 @@ if ( ! class_exists( 'TC_post_list_design' ) ) :
             $this -> tc_post_list_design_hooks();
             add_action( '__before_article', array($this, 'tc_post_list_design_loop_hooks'), 0 );
         }
-        
+
         function tc_post_list_design_hooks(){
 
             $this -> tc_force_post_list_excerpt();
-            
+
             $this -> tc_force_post_list_thumbnails();
-       
-            remove_filter('tc_post_list_layout', 
+
+            remove_filter('tc_post_list_layout',
                             array( TC_post_list::$instance, 'tc_set_post_list_layout') );
-            add_filter('tc_post_list_layout', 
+            add_filter('tc_post_list_layout',
                             array( $this, 'tc_set_post_list_layout') );
- 
+
             //TODO if on what kind of post list + options
             //case simple post_list
-            add_filter( 'tc_post_list_selectors', 
+            add_filter( 'tc_post_list_selectors',
                             array($this, 'tc_post_list_design_article_selectors') );
         }
 
@@ -58,15 +133,15 @@ if ( ! class_exists( 'TC_post_list_design' ) ) :
                 return;
 
             $this -> tc_print_row_fluid_section_wrapper();
-            
-            add_action( '__after_article', 
+
+            add_action( '__after_article',
                             array( $this, 'tc_print_row_fluid_section_wrapper' ), 0 );
             add_filter( 'tc_post_list_separator', '__return_empty_string' );
 
         }
 
         function tc_get_post_list_cols(){
-            return apply_filters( 'tc_post_list_design_cols', 
+            return apply_filters( 'tc_post_list_design_cols',
                 esc_attr( tc__f('__get_option', 'tc_post_list_design_cols') ) );
         }
 
@@ -88,14 +163,14 @@ if ( ! class_exists( 'TC_post_list_design' ) ) :
             add_filter( 'post_class',
                 array( $this , 'tc_add_thumb_shape_name'));
 
-            remove_filter('tc_thumb_size_name', 
+            remove_filter('tc_thumb_size_name',
                 array( TC_post_thumbnails::$instance, 'tc_set_thumb_size') );
-            add_filter('tc_thumb_size_name', 
+            add_filter('tc_thumb_size_name',
                 array( $this, 'tc_post_list_design_thumbs') );
 
-            remove_filter('tc_post_thumb_wrapper', 
+            remove_filter('tc_post_thumb_wrapper',
                 array( TC_post_thumbnails::$instance, 'tc_set_thumb_shape') );
-            add_filter('tc_post_thumb_wrapper', 
+            add_filter('tc_post_thumb_wrapper',
                 array( $this, 'tc_set_thumb_shape'), 10, 2 );
         }
 
@@ -125,7 +200,7 @@ if ( ! class_exists( 'TC_post_list_design' ) ) :
             $layout['show_thumb_first'] = ( 'top' == $_position ) ? true : false;
             $layout['content']          = 'span12';
             $layout['thumb']            = 'span12';
-            
+
             return $layout;
         }
 
@@ -145,14 +220,14 @@ if ( ! class_exists( 'TC_post_list_design' ) ) :
 
             $current_filter = current_filter();
             $cols = $this -> tc_get_post_list_cols();
-            
-            if ( '__before_article' == $current_filter && 
+
+            if ( '__before_article' == $current_filter &&
                 ( $start_post == $current_post || 0 == ( $current_post - $start_post ) % $cols ) )
                 echo apply_filters( 'tc_post_list_design_grid_section', '<section class="tc-post-list-design-grid row-fluid cols-'.$cols.'">' );
-            elseif (  '__after_article' == $current_filter && 
+            elseif (  '__after_article' == $current_filter &&
                       ( $wp_query->post_count == ( $current_post + 1 ) ||
                         0 == ( ( $current_post - $start_post + 1 ) % $cols ) ) ){
-                            
+
                 echo '</section><!--end section.tc-post-list-design.row-fluid-->';
                 echo apply_filters( 'tc_post_list_design_separator', '<hr class="featurette-divider post-list-design">' );
             }

--- a/inc/parts/class-content-post_list_design.php
+++ b/inc/parts/class-content-post_list_design.php
@@ -22,6 +22,10 @@ if ( ! class_exists( 'TC_post_list_design' ) ) :
 
         function tc_alter_main_query() {
           global $wp_query;
+          //only apply to home or blog posts page
+          if ( ! $wp_query->is_posts_page || ! is_home() )
+            return;
+
           $_query_vars    = $wp_query->query_vars;
           $page           =  ( ! isset($_query_vars['paged']) || ! $_query_vars['paged'] ) ? 0 : $_query_vars['paged'];
 
@@ -83,15 +87,6 @@ if ( ! class_exists( 'TC_post_list_design' ) ) :
               }
             }
           }
-
-
-          /*?>
-            <pre>
-              <?php print_r($wp_query); ?>
-            </pre>
-          <?php*/
-          ?>
-          <?php
         }
 
         function tc_post_list_design(){


### PR DESCRIPTION
sorry for the confusion, I has choosen the wrong branch at first!

I have closed the previous pull request and update my code to handle the case when the user decide to display the posts on a specific page

I have used the code from WP core in wp-includes/query.php around line #3352

The idea is to put the sticky post at the first position and to complete the columns with missing post.

I did not fix the layout issue forcing all first post to be expanded.
I think that there should be an additional condition in the tc_get_post_list_expand_featured() method looking like :
```php
... && in_array( get_the_ID() , get_option('sticky_posts'))

I have tested it with the 4 different layouts + on home and page for blog